### PR TITLE
Install go-plus instead of go-config and go-get

### DIFF
--- a/package.json
+++ b/package.json
@@ -20,8 +20,7 @@
     "atom-package-deps": "^4.0.1"
   },
   "package-deps": [
-    "go-config",
-    "go-get"
+    "go-plus"
   ],
   "consumedServices": {
     "go-config": {


### PR DESCRIPTION
As part of https://github.com/joefitzgerald/go-plus/pull/503, `go-config` and `go-get` will be unpublished. `go-plus` now provides the `go-config` and `go-get` services.

This PR should be merged and released when `v5.0.0` of `go-plus` is published, which should occur on the 19th December at 4:00 pm UTC (https://www.timeanddate.com/worldclock/meetingdetails.html?year=2016&month=12&day=19&hour=16&min=0&sec=0&p1=75).