### PR TITLE
Fix race condition in init

### DIFF
--- a/lib/go-signature-statusbar.js
+++ b/lib/go-signature-statusbar.js
@@ -24,7 +24,7 @@ export default {
   },
 
   addStatusBarTile () {
-    if (!this.initDone && this.statusBar) {
+    if (!this.initDone && this.statusBar && this.goconfig) {
       this.goSignatureStatusbarView = new GoSignatureStatusbarView(this.goconfig)
       this.subscriptions.add(atom.workspace.onDidChangeActivePaneItem((activeItem) => {
         this.goSignatureStatusbarView.activate()
@@ -38,6 +38,7 @@ export default {
 
   consumeGoconfig (service) {
     this.goconfig = service
+    this.addStatusBarTile()
   },
 
   consumeStatusBar (statusBar) {


### PR DESCRIPTION
The consume functions can be called in any order.
If consumeStatusBar is called before consumeGoconfig, the init code will throw an error.

Fixes #13, fixes #16